### PR TITLE
added mod.rs, lib.rs references interrupts module

### DIFF
--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -1,0 +1,94 @@
+/// Interrupt active setting for the INT_DRDY pin: active high (default) or active low
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+pub enum IntActive {
+    /// Active high
+    High,
+    /// Active low
+    Low,
+}
+
+impl IntActive {
+    pub fn status(self) -> u8 {
+        match self {
+            IntActive::High => 0,
+            IntActive::Low => 1,
+        }
+    }
+}
+
+/// Interrupt pad setting for INT_DRDY pin: push-pull (default) or open-drain.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+pub enum IntPin {
+    /// Push-pull
+    PushPull,
+    /// Open drain
+    OpenDrain,
+}
+
+impl IntPin {
+    pub fn status(self) -> u8 {
+        match self {
+            IntPin::PushPull => 0,
+            IntPin::OpenDrain => 1,
+        }
+    }
+}
+
+/// Interrupt latching setting (interrupt request latched or not latched)
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+pub enum IntLatch {
+    /// Interrupt request latched
+    Latched,
+    /// Interrupt request not latched
+    NotLatched,
+}
+
+impl IntLatch {
+    pub fn status(self) -> u8 {
+        match self {
+            IntLatch::Latched => 1,
+            IntLatch::NotLatched => 0,
+        }
+    }
+}
+
+/// 6D or 4D used by interrupt generator for for position recognition
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+pub enum PosRecog {
+    /// 4D option used for position recognition
+    _4D,
+    /// 4D option used for position recognition
+    _6D,
+}
+
+impl PosRecog {
+    pub fn status(self) -> u8 {
+        match self {
+            PosRecog::_4D => 1,
+            PosRecog::_6D => 0,
+        }
+    }
+}
+
+/// Decrement or reset counter mode selection.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy)]
+pub enum Counter {
+    /// Decrement counter (see pages 58-61)
+    Decrement,
+    /// Reset counter
+    Reset,
+}
+
+impl Counter {
+    pub fn status(self) -> u8 {
+        match self {
+            Counter::Decrement => 1,
+            Counter::Reset => 0,
+        }
+    }
+}

--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -9,7 +9,7 @@ pub enum IntActive {
 }
 
 impl IntActive {
-    pub fn status(self) -> u8 {
+    pub fn value(self) -> u8 {
         match self {
             IntActive::High => 0,
             IntActive::Low => 1,
@@ -28,7 +28,7 @@ pub enum IntPin {
 }
 
 impl IntPin {
-    pub fn status(self) -> u8 {
+    pub fn value(self) -> u8 {
         match self {
             IntPin::PushPull => 0,
             IntPin::OpenDrain => 1,
@@ -47,7 +47,7 @@ pub enum IntLatch {
 }
 
 impl IntLatch {
-    pub fn status(self) -> u8 {
+    pub fn value(self) -> u8 {
         match self {
             IntLatch::Latched => 1,
             IntLatch::NotLatched => 0,
@@ -66,7 +66,7 @@ pub enum PosRecog {
 }
 
 impl PosRecog {
-    pub fn status(self) -> u8 {
+    pub fn value(self) -> u8 {
         match self {
             PosRecog::_4D => 1,
             PosRecog::_6D => 0,
@@ -85,7 +85,7 @@ pub enum Counter {
 }
 
 impl Counter {
-    pub fn status(self) -> u8 {
+    pub fn value(self) -> u8 {
         match self {
             Counter::Decrement => 1,
             Counter::Reset => 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod accel;
 pub mod fifo;
 pub mod gyro;
+pub mod interrupts;
 pub mod mag;
 pub mod register;
 


### PR DESCRIPTION
Let's see if I got this one right. For now it's just the `mod.rs`, and a reference to the `interrupts` module in `lib.rs`. I made all the enum names CamelCase, and they all return `u8`, which will be easier to use in various functions, as we discussed. 
I also noticed that there is one more function to be added, in `gyro_int`, to set the counter behavior, will do that.