### PR TITLE
Add interrupt

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,250 @@
+//! Configuration trait, trait implementations
+use crate::{
+    accel::AccelSettings,
+    fifo::{Decimate, FIFOConfig},
+    gyro::GyroSettings,
+    interface::Sensor,
+    interrupts::{
+        accel_int::IntConfigAccel,
+        gyro_int::IntConfigGyro,
+        mag_int::IntConfigMag,
+        pins_config::{IntConfigAG1, IntConfigAG2, PinConfig},
+    },
+    mag::MagSettings,
+    register,
+};
+
+pub trait ConfigToWrite {
+    fn byte(&self) -> u8;
+    fn sensor(&self) -> Sensor;
+    fn addr(&self) -> u8;
+}
+
+/// Generic `Configuration` struct
+pub struct Configuration {
+    pub sensor: Sensor,
+    pub register: u8,
+    pub value: u8,
+}
+
+impl ConfigToWrite for Configuration {
+    fn addr(&self) -> u8 {
+        self.register
+    }
+    fn sensor(&self) -> Sensor {
+        self.sensor
+    }
+    fn byte(&self) -> u8 {
+        self.value
+    }
+}
+
+impl ConfigToWrite for PinConfig {
+    fn byte(&self) -> u8 {
+        self.ctrl_reg8()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Accelerometer
+    }
+    fn addr(&self) -> u8 {
+        register::AG::CTRL_REG8.addr()
+    }
+}
+
+impl ConfigToWrite for IntConfigAccel {
+    fn byte(&self) -> u8 {
+        self.int_gen_cfg_xl()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Accelerometer
+    }
+    fn addr(&self) -> u8 {
+        register::AG::INT_GEN_CFG_XL.addr()
+    }
+}
+
+impl ConfigToWrite for IntConfigAG1 {
+    fn byte(&self) -> u8 {
+        self.int1_ctrl()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Accelerometer
+    }
+    fn addr(&self) -> u8 {
+        register::AG::INT1_CTRL.addr()
+    }
+}
+
+impl ConfigToWrite for IntConfigAG2 {
+    fn byte(&self) -> u8 {
+        self.int2_ctrl()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Accelerometer
+    }
+    fn addr(&self) -> u8 {
+        register::AG::INT2_CTRL.addr()
+    }
+}
+
+impl ConfigToWrite for IntConfigGyro {
+    fn byte(&self) -> u8 {
+        self.int_gen_cfg_g()
+    }
+    fn addr(&self) -> u8 {
+        register::AG::INT_GEN_CFG_G.addr()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Gyro
+    }
+}
+
+impl ConfigToWrite for IntConfigMag {
+    fn byte(&self) -> u8 {
+        self.int_cfg_m()
+    }
+    fn addr(&self) -> u8 {
+        register::Mag::INT_CFG_M.addr()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Magnetometer
+    }
+}
+
+impl ConfigToWrite for Decimate {
+    fn byte(&self) -> u8 {
+        self.value()
+    }
+    fn addr(&self) -> u8 {
+        register::AG::CTRL_REG5_XL.addr()
+    }
+    fn sensor(&self) -> Sensor {
+        Sensor::Accelerometer
+    }
+}
+
+impl AccelSettings {
+    /// Returns `Configuration` to write to CTRL_REG5_XL (0x1F)
+    pub fn ctrl_reg5_xl_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg5_xl(),
+            sensor: Sensor::Accelerometer,
+            register: register::AG::CTRL_REG5_XL.addr(),
+        }
+    }
+
+    /// Returns `Configuration` to write to CTRL_REG6_XL (0x20)
+    pub fn ctrl_reg6_xl_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg6_xl(),
+            sensor: Sensor::Accelerometer,
+            register: register::AG::CTRL_REG6_XL.addr(),
+        }
+    }
+
+    /// Returns `Configuration` to write to CTRL_REG7_XL (0x21)
+    pub fn ctrl_reg7_xl_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg7_xl(),
+            sensor: Sensor::Accelerometer,
+            register: register::AG::CTRL_REG7_XL.addr(),
+        }
+    }
+}
+
+impl GyroSettings {
+    /// Returns `Configuration` to write to CTRL_REG1_G. See page 45
+    pub fn ctrl_reg1_g_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg1_g(),
+            sensor: Sensor::Gyro,
+            register: register::AG::CTRL_REG1_G.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG2_G. See page 47
+    pub fn ctrl_reg2_g_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg2_g(),
+            sensor: Sensor::Gyro,
+            register: register::AG::CTRL_REG2_G.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG3_G. See page 47
+    pub fn ctrl_reg3_g_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg3_g(),
+            sensor: Sensor::Gyro,
+            register: register::AG::CTRL_REG3_G.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG4. See page 50
+    pub fn ctrl_reg4_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg4(),
+            sensor: Sensor::Gyro,
+            register: register::AG::CTRL_REG4.addr(),
+        }
+    }
+}
+
+impl MagSettings {
+    /// Returns `Configuration` to write to CTRL_REG1_M. See page 63.
+    pub fn ctrl_reg1_m_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg1_m(),
+            sensor: Sensor::Magnetometer,
+            register: register::Mag::CTRL_REG1_M.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG2_M.
+    pub fn ctrl_reg2_m_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg2_m(),
+            sensor: Sensor::Magnetometer,
+            register: register::Mag::CTRL_REG2_M.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG3_M.
+    pub fn ctrl_reg3_m_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg3_m(),
+            sensor: Sensor::Magnetometer,
+            register: register::Mag::CTRL_REG3_M.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG4_M.
+    pub fn ctrl_reg4_m_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg4_m(),
+            sensor: Sensor::Magnetometer,
+            register: register::Mag::CTRL_REG4_M.addr(),
+        }
+    }
+    /// Returns `Configuration` to write to CTRL_REG5_M.
+    pub fn ctrl_reg5_m_config(&self) -> Configuration {
+        Configuration {
+            value: self.ctrl_reg5_m(),
+            sensor: Sensor::Magnetometer,
+            register: register::Mag::CTRL_REG5_M.addr(),
+        }
+    }
+}
+
+impl FIFOConfig {
+    /// Returns `Configuration` to be written to FIFO_CTRL.
+    pub fn f_fifo_ctrl_config(&self) -> Configuration {
+        Configuration {
+            value: self.f_fifo_ctrl(),
+            sensor: Sensor::Accelerometer,
+            register: register::AG::FIFO_CTRL.addr(),
+        }
+    }
+
+    pub fn f_ctrl_reg9_config(&self) -> Configuration {
+        Configuration {
+            sensor: Sensor::Accelerometer,
+            register: register::AG::CTRL_REG9.addr(),
+            value: self.f_ctrl_reg9(),
+        }
+    }
+}

--- a/src/interrupts/accel_int.rs
+++ b/src/interrupts/accel_int.rs
@@ -1,6 +1,6 @@
 //! Functions related to accelerometer-specific interrupts
 ///
-/// TO DO:
+/// TODO:
 /// - set acceleration threshold for X, Y and Z axis (INT_GEN_THS_X/Y/Z_XL) in mg instead?
 /// - LIR_XL1 and 4D_XL1 bits of CTRL_REG4 => should they be incorporated in the Config struct? what's the relation between 4D_XL1 and _6D?
 ///

--- a/src/interrupts/accel_int.rs
+++ b/src/interrupts/accel_int.rs
@@ -1,0 +1,167 @@
+//! Functions related to accelerometer-specific interrupts
+///
+/// TO DO:
+/// - set acceleration threshold for X, Y and Z axis (INT_GEN_THS_X/Y/Z_XL) in mg instead?
+/// - LIR_XL1 and 4D_XL1 bits of CTRL_REG4 => should they be incorporated in the Config struct? what's the relation between 4D_XL1 and _6D?
+///
+use super::*;
+
+/// Accelerometer interrupt generation settings
+#[derive(Debug)]
+pub struct IntConfigAccel {
+    /// Combination of accelerometer's interrupt events
+    pub events_combination: Combination,
+    /// Enable 6-direction detection
+    pub enable_6d: Flag,
+    /// Enable interrupt generation on Z-axis high event
+    pub interrupt_zaxis_high: Flag,
+    /// Enable interrupt generation on Z-axis low event
+    pub interrupt_zaxis_low: Flag,
+    /// Enable interrupt generation on Y-axis high event
+    pub interrupt_yaxis_high: Flag,
+    /// Enable interrupt generation on Y-axis low event
+    pub interrupt_yaxis_low: Flag,
+    /// Enable interrupt generation on X-axis high event
+    pub interrupt_xaxis_high: Flag,
+    /// Enable interrupt generation on X-axis low event
+    pub interrupt_xaxis_low: Flag,
+}
+
+impl Default for IntConfigAccel {
+    fn default() -> Self {
+        IntConfigAccel {
+            events_combination: Combination::Or,
+            enable_6d: Flag::Disabled,
+            interrupt_zaxis_high: Flag::Disabled,
+            interrupt_zaxis_low: Flag::Disabled,
+            interrupt_yaxis_high: Flag::Disabled,
+            interrupt_yaxis_low: Flag::Disabled,
+            interrupt_xaxis_high: Flag::Disabled,
+            interrupt_xaxis_low: Flag::Disabled,
+        }
+    }
+}
+
+impl IntConfigAccel {
+    /// Returns values to be written to INT_GEN_CFG_XL:    
+    pub(crate) fn int_gen_cfg_xl(&self) -> u8 {
+        let mut data = 0u8;
+        data |= self.events_combination.value() << 7;
+        data |= self.enable_6d.value() << 6;
+        data |= self.interrupt_zaxis_high.value() << 5;
+        data |= self.interrupt_zaxis_low.value() << 4;
+        data |= self.interrupt_yaxis_high.value() << 3;
+        data |= self.interrupt_yaxis_low.value() << 2;
+        data |= self.interrupt_xaxis_high.value() << 1;
+        data |= self.interrupt_xaxis_low.value();
+        data
+    }
+}
+
+impl From<u8> for IntConfigAccel {
+    fn from(reg_value: u8) -> Self {
+        IntConfigAccel {
+            events_combination: match reg_value & CfgBitmasks::AOI_XL {
+                x if x > 0 => Combination::And,
+                _ => Combination::Or,
+            },
+            enable_6d: match reg_value & CfgBitmasks::_6D {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_zaxis_high: match reg_value & CfgBitmasks::ZHIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_zaxis_low: match reg_value & CfgBitmasks::ZLIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_yaxis_high: match reg_value & CfgBitmasks::YHIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_yaxis_low: match reg_value & CfgBitmasks::YLIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_xaxis_high: match reg_value & CfgBitmasks::XHIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_xaxis_low: match reg_value & CfgBitmasks::XLIE_XL {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+        }
+    }
+}
+
+/// Bitmasks for interrupt-related settings in INT_GEN_SRC_XL register
+pub(crate) struct InterruptBitmasks;
+
+#[allow(dead_code)]
+impl InterruptBitmasks {
+    pub const IA_XL: u8 = 0b0100_0000;
+    pub const ZH_XL: u8 = 0b0010_0000;
+    pub const ZL_XL: u8 = 0b0001_0000;
+    pub const YH_XL: u8 = 0b0000_1000;
+    pub const YL_XL: u8 = 0b0000_0100;
+    pub const XH_XL: u8 = 0b0000_0010;
+    pub const XL_XL: u8 = 0b0000_0001;
+}
+
+/// Bitmasks for interrupt-related settings in INT_GEN_CFG_XL register
+pub(crate) struct CfgBitmasks;
+
+#[allow(dead_code)]
+impl CfgBitmasks {
+    pub const AOI_XL: u8 = 0b1000_0000;
+    pub const _6D: u8 = 0b0100_0000;
+    pub const ZHIE_XL: u8 = 0b0010_0000;
+    pub const ZLIE_XL: u8 = 0b0001_0000;
+    pub const YHIE_XL: u8 = 0b0000_1000;
+    pub const YLIE_XL: u8 = 0b0000_0100;
+    pub const XHIE_XL: u8 = 0b0000_0010;
+    pub const XLIE_XL: u8 = 0b0000_0001;
+
+    pub const LIR_XL1: u8 = 0b0000_0010;
+    pub const _4D_XL1: u8 = 0b0000_0001;
+}
+
+#[derive(Debug)]
+/// Contents of the INT_GEN_SRC_XL register (interrupt active and differential pressure events flags)
+pub struct IntStatusAccel {
+    pub interrupt_active: bool,
+    pub xaxis_high_event: bool,
+    pub xaxis_low_event: bool,
+    pub yaxis_high_event: bool,
+    pub yaxis_low_event: bool,
+    pub zaxis_high_event: bool,
+    pub zaxis_low_event: bool,
+}
+
+#[test]
+fn configure_accel_int() {
+    let config = IntConfigAccel::default();
+    assert_eq!(config.int_gen_cfg_xl(), 0b0000_0000);
+
+    let config = IntConfigAccel {
+        events_combination: Combination::And,
+        enable_6d: Flag::Enabled,
+        interrupt_zaxis_high: Flag::Enabled,
+        interrupt_zaxis_low: Flag::Enabled,
+        interrupt_yaxis_high: Flag::Enabled,
+        interrupt_yaxis_low: Flag::Enabled,
+        interrupt_xaxis_high: Flag::Enabled,
+        interrupt_xaxis_low: Flag::Enabled,
+    };
+    assert_eq!(config.int_gen_cfg_xl(), 0b1111_1111);
+
+    let config = IntConfigAccel {
+        interrupt_zaxis_high: Flag::Enabled,
+        interrupt_xaxis_low: Flag::Enabled,
+        ..Default::default()
+    };
+    assert_eq!(config.int_gen_cfg_xl(), 0b0010_0001);
+}

--- a/src/interrupts/gyro_int.rs
+++ b/src/interrupts/gyro_int.rs
@@ -1,6 +1,6 @@
 //! Functions related to gyroscope-specific interrupts
 ///
-/// TO DO:
+/// TODO:
 /// - complete gyroscope threshold setting for X, Y and Z axis (INT_GEN_THS_X/Y/Z_G)
 /// - ORIENT_CFG_G settings (user orientation selection (???)) -> to be done in gyro.rs
 ///

--- a/src/interrupts/gyro_int.rs
+++ b/src/interrupts/gyro_int.rs
@@ -1,0 +1,157 @@
+//! Functions related to gyroscope-specific interrupts
+///
+/// TO DO:
+/// - complete gyroscope threshold setting for X, Y and Z axis (INT_GEN_THS_X/Y/Z_G)
+/// - ORIENT_CFG_G settings (user orientation selection (???)) -> to be done in gyro.rs
+///
+use super::*;
+
+/// Gyroscope interrupt generator settings
+#[derive(Debug)]
+pub struct IntConfigGyro {
+    /// Combination of gyroscope interrupt events
+    pub events_combination: Combination,
+    /// Latch interrupt request
+    pub latch_interrupts: IntLatch,
+    /// Enable interrupt generation on Z-axis (yaw) high event
+    pub interrupt_high_zaxis: Flag,
+    /// Enable interrupt generation on Z-axis (yaw) low event
+    pub interrupt_low_zaxis: Flag,
+    /// Enable interrupt generation on Y-axis (roll) high event
+    pub interrupt_high_yaxis: Flag,
+    /// Enable interrupt generation on Y-axis (roll) low event
+    pub interrupt_low_yaxis: Flag,
+    /// Enable interrupt generation on X-axis (pitch) high event
+    pub interrupt_high_xaxis: Flag,
+    /// Enable interrupt generation on X-axis (pitch) low event
+    pub interrupt_low_xaxis: Flag,
+}
+
+impl Default for IntConfigGyro {
+    fn default() -> Self {
+        IntConfigGyro {
+            events_combination: Combination::Or,
+            latch_interrupts: IntLatch::NotLatched,
+            interrupt_high_zaxis: Flag::Disabled,
+            interrupt_low_zaxis: Flag::Disabled,
+            interrupt_high_yaxis: Flag::Disabled,
+            interrupt_low_yaxis: Flag::Disabled,
+            interrupt_high_xaxis: Flag::Disabled,
+            interrupt_low_xaxis: Flag::Disabled,
+        }
+    }
+}
+
+impl IntConfigGyro {
+    /// Returns `u8` to be written to INT_GEN_CFG_G:    
+    pub(crate) fn int_gen_cfg_g(&self) -> u8 {
+        let mut data = 0u8;
+        data |= self.events_combination.value() << 7;
+        data |= self.latch_interrupts.value() << 6;
+        data |= self.interrupt_high_zaxis.value() << 5;
+        data |= self.interrupt_low_zaxis.value() << 4;
+        data |= self.interrupt_high_yaxis.value() << 3;
+        data |= self.interrupt_low_yaxis.value() << 2;
+        data |= self.interrupt_high_xaxis.value() << 1;
+        data |= self.interrupt_low_xaxis.value();
+        data
+    }
+}
+
+impl From<u8> for IntConfigGyro {
+    fn from(reg_value: u8) -> Self {
+        IntConfigGyro {
+            events_combination: match reg_value & CfgBitmasks::AOI_G {
+                x if x > 0 => Combination::And,
+                _ => Combination::Or,
+            },
+            latch_interrupts: match reg_value & CfgBitmasks::LIR_G {
+                x if x > 0 => IntLatch::Latched,
+                _ => IntLatch::NotLatched,
+            },
+            interrupt_high_zaxis: match reg_value & CfgBitmasks::ZHIE_G {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_low_zaxis: match reg_value & CfgBitmasks::ZLIE_G {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_high_yaxis: match reg_value & CfgBitmasks::YHIE_G {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_low_yaxis: match (reg_value & CfgBitmasks::YLIE_G) >> 2 {
+                1 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_high_xaxis: match (reg_value & CfgBitmasks::XHIE_G) >> 1 {
+                1 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_low_xaxis: match reg_value & CfgBitmasks::XLIE_G {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+        }
+    }
+}
+
+/// Bitmasks for interrupt-related settings in INT_GEN_SRC_G register
+pub(crate) struct InterruptBitmasks;
+
+#[allow(dead_code)]
+impl InterruptBitmasks {
+    pub const IA_G: u8 = 0b0100_0000;
+    pub const ZH_G: u8 = 0b0010_0000;
+    pub const ZL_G: u8 = 0b0001_0000;
+    pub const YH_G: u8 = 0b0000_1000;
+    pub const YL_G: u8 = 0b0000_0100;
+    pub const XH_G: u8 = 0b0000_0010;
+    pub const XL_G: u8 = 0b0000_0001;
+}
+
+/// Bitmasks for interrupt-related settings in INT_GEN_CFG_G register
+pub(crate) struct CfgBitmasks;
+
+#[allow(dead_code)]
+impl CfgBitmasks {
+    pub const AOI_G: u8 = 0b1000_0000;
+    pub const LIR_G: u8 = 0b0100_0000;
+    pub const ZHIE_G: u8 = 0b0010_0000;
+    pub const ZLIE_G: u8 = 0b0001_0000;
+    pub const YHIE_G: u8 = 0b0000_1000;
+    pub const YLIE_G: u8 = 0b0000_0100;
+    pub const XHIE_G: u8 = 0b0000_0010;
+    pub const XLIE_G: u8 = 0b0000_0001;
+}
+
+#[derive(Debug)]
+/// Contents of the INT_GEN_SRC_G register (interrupt active and differential pressure events Flags)
+pub struct IntStatusGyro {
+    pub interrupt_active: bool,
+    pub xaxis_high_event: bool,
+    pub xaxis_low_event: bool,
+    pub yaxis_high_event: bool,
+    pub yaxis_low_event: bool,
+    pub zaxis_high_event: bool,
+    pub zaxis_low_event: bool,
+}
+
+#[test]
+fn configure_gyro_int() {
+    let config = IntConfigGyro::default();
+    assert_eq!(config.int_gen_cfg_g(), 0b0000_0000);
+
+    let config = IntConfigGyro {
+        events_combination: Combination::And,
+        latch_interrupts: IntLatch::Latched,
+        interrupt_high_xaxis: Flag::Enabled,
+        interrupt_high_yaxis: Flag::Enabled,
+        interrupt_high_zaxis: Flag::Enabled,
+        interrupt_low_xaxis: Flag::Enabled,
+        interrupt_low_yaxis: Flag::Enabled,
+        interrupt_low_zaxis: Flag::Enabled,
+    };
+    assert_eq!(config.int_gen_cfg_g(), 0b1111_1111);
+}

--- a/src/interrupts/mag_int.rs
+++ b/src/interrupts/mag_int.rs
@@ -1,0 +1,140 @@
+//! Functions related to magnetometer-specific interrupts
+use super::*;
+
+/// Magnetometer interrupt pin (INT_CFG_M) settings
+#[derive(Debug)]
+pub struct IntConfigMag {
+    /// Enable interrupt generation on X-axis, default 0
+    pub interrupt_xaxis: Flag,
+    /// Enable interrupt generation on Y-axis, default 0
+    pub interrupt_yaxis: Flag,
+    /// Enable interrupt generation on Z-axis, default 0
+    pub interrupt_zaxis: Flag,
+    /// Configure interrupt pin INT_M as active high or active low, default 0 (low)
+    pub active_high_or_low: IntActive,
+    /// Latch interrupt request (Once latched, the INT_M pin remains in the same state until INT_SRC_M is read), default 0 (latched)
+    pub interrupt_latching: IntLatch,
+    /// Interrupt enable on the INT_M pin, default 0
+    pub enable_interrupt: Flag,
+}
+
+impl Default for IntConfigMag {
+    fn default() -> Self {
+        IntConfigMag {
+            interrupt_xaxis: Flag::Disabled,
+            interrupt_yaxis: Flag::Disabled,
+            interrupt_zaxis: Flag::Disabled,
+            active_high_or_low: IntActive::Low,       // reversed!
+            interrupt_latching: IntLatch::NotLatched, // NOTE: it's reversed, 0 is latched (default)
+            enable_interrupt: Flag::Disabled,
+        }
+    }
+}
+
+impl IntConfigMag {
+    /// Returns `u8` to be written to INT_CFG_M:    
+    pub(crate) fn int_cfg_m(&self) -> u8 {
+        let mut data = 0u8;
+        data |= self.interrupt_xaxis.value() << 7;
+        data |= self.interrupt_yaxis.value() << 6;
+        data |= self.interrupt_zaxis.value() << 5;
+        data |= match self.active_high_or_low {
+            IntActive::High => 1,
+            IntActive::Low => 0,
+        } << 2;
+        data |= match self.interrupt_latching {
+            IntLatch::Latched => 0,
+            IntLatch::NotLatched => 1,
+        } << 1;
+        data |= self.enable_interrupt.value();
+        data
+    }
+}
+
+impl From<u8> for IntConfigMag {
+    fn from(reg_value: u8) -> Self {
+        IntConfigMag {
+            interrupt_xaxis: match reg_value & CfgBitmasks::XIEN {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_yaxis: match reg_value & CfgBitmasks::YIEN {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            interrupt_zaxis: match reg_value & CfgBitmasks::ZIEN {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+            active_high_or_low: match reg_value & CfgBitmasks::IEA {
+                x if x > 0 => IntActive::High,
+                _ => IntActive::Low,
+            },
+            interrupt_latching: match reg_value & CfgBitmasks::IEL {
+                x if x > 0 => IntLatch::NotLatched,
+                _ => IntLatch::Latched, // NOTE: it's reversed, 0 is latched
+            },
+            enable_interrupt: match reg_value & CfgBitmasks::IEN {
+                x if x > 0 => Flag::Enabled,
+                _ => Flag::Disabled,
+            },
+        }
+    }
+}
+
+/// Bitmasks for interrupt-related settings in INT_SRC_M register
+pub(crate) struct InterruptBitmasks;
+
+#[allow(dead_code)]
+impl InterruptBitmasks {
+    pub const PTH_X: u8 = 0b1000_0000;
+    pub const PTH_Y: u8 = 0b0100_0000;
+    pub const PTH_Z: u8 = 0b0010_0000;
+    pub const NTH_X: u8 = 0b0001_0000;
+    pub const NTH_Y: u8 = 0b0000_1000;
+    pub const NTH_Z: u8 = 0b0000_0100;
+    pub const MROI: u8 = 0b0000_0010;
+    pub const INT: u8 = 0b0000_0001;
+}
+
+/// Bitmasks for interrupt-related settings in INT_CFG_M register
+pub(crate) struct CfgBitmasks;
+
+#[allow(dead_code)]
+impl CfgBitmasks {
+    pub const XIEN: u8 = 0b1000_0000;
+    pub const YIEN: u8 = 0b0100_0000;
+    pub const ZIEN: u8 = 0b0010_0000;
+    pub const IEA: u8 = 0b0000_0100;
+    pub const IEL: u8 = 0b0000_0010;
+    pub const IEN: u8 = 0b0000_0001;
+}
+
+#[derive(Debug)]
+/// Contents of the INT_SRC_M register (interrupt active and threshold excess events Flags)
+pub struct IntStatusMag {
+    pub xaxis_exceeds_thresh_pos: bool,
+    pub yaxis_exceeds_thresh_pos: bool,
+    pub zaxis_exceeds_thresh_pos: bool,
+    pub xaxis_exceeds_thresh_neg: bool,
+    pub yaxis_exceeds_thresh_neg: bool,
+    pub zaxis_exceeds_thresh_neg: bool,
+    pub measurement_range_overflow: bool,
+    pub interrupt_occurs: bool,
+}
+
+#[test]
+fn configure_mag_int() {
+    let config = IntConfigMag::default();
+    assert_eq!(config.int_cfg_m(), 0b0000_0010);
+
+    let config = IntConfigMag {
+        interrupt_xaxis: Flag::Enabled,
+        interrupt_yaxis: Flag::Enabled,
+        interrupt_zaxis: Flag::Enabled,
+        active_high_or_low: IntActive::High,
+        interrupt_latching: IntLatch::Latched,
+        enable_interrupt: Flag::Enabled,
+    };
+    assert_eq!(config.int_cfg_m(), 0b1110_0101);
+}

--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -1,5 +1,8 @@
 //! Enums used by various interrupt-related functions
 
+pub mod accel_int;
+pub mod gyro_int;
+pub mod mag_int;
 pub mod pins_config;
 
 /// Interrupt active setting for the INT_DRDY pin: active high (default) or active low

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,20 +6,25 @@
 #![no_std]
 // #![deny(warnings, missing_docs)]
 pub mod accel;
+pub mod configuration;
 pub mod fifo;
 pub mod gyro;
+pub mod interface;
 pub mod interrupts;
 pub mod mag;
 pub mod register;
 
 use accel::AccelSettings;
+use configuration::ConfigToWrite;
 use fifo::{Decimate, FIFOBitmasks, FIFOConfig, FIFOStatus};
 use gyro::GyroSettings;
-use interrupts::pins_config::{IntConfigAG1, IntConfigAG2, PinConfig};
-use mag::MagSettings;
-
-pub mod interface;
 use interface::{Interface, Sensor};
+use interrupts::accel_int::IntConfigAccel;
+use interrupts::gyro_int::IntConfigGyro;
+use interrupts::mag_int::IntConfigMag;
+use interrupts::pins_config::{self, IntConfigAG1, IntConfigAG2, PinConfig};
+use mag::MagSettings;
+use pins_config::PinConfigBitmask;
 
 /// Accelerometer/Gyroscope's ID
 const WHO_AM_I_AG: u8 = 0x68;
@@ -72,16 +77,32 @@ impl<T> LSM9DS1<T>
 where
     T: Interface,
 {
+    /// Write a configuration to a register.
+    fn write_register<C: ConfigToWrite>(&mut self, config: C) -> Result<(), T::Error> {
+        self.interface
+            .write(config.sensor(), config.addr(), config.byte())?;
+        Ok(())
+    }
+    /// Modify a register with a configuration.
+    fn modify_register<C: ConfigToWrite>(
+        &mut self,
+        config: C,
+        original_value: u8,
+        bitmask: u8,
+    ) -> Result<(), T::Error> {
+        let mut data: u8 = original_value & bitmask;
+        data |= config.byte();
+        self.interface.write(config.sensor(), config.addr(), data)?;
+        Ok(())
+    }
+
     fn reachable(&mut self, sensor: Sensor) -> Result<bool, T::Error> {
         use Sensor::*;
-        let mut bytes = [0u8; 1];
         let (who_am_i, register) = match sensor {
             Accelerometer | Gyro | Temperature => (WHO_AM_I_AG, register::AG::WHO_AM_I.addr()),
             Magnetometer => (WHO_AM_I_M, register::Mag::WHO_AM_I.addr()),
         };
-
-        self.interface.read(sensor, register, &mut bytes)?;
-        Ok(bytes[0] == who_am_i)
+        Ok(self.read_register(sensor, register)? == who_am_i)
     }
 
     /// Verifies communication with WHO_AM_I register
@@ -94,74 +115,26 @@ where
     }
     /// Initializes Accelerometer with sensor settings.
     pub fn begin_accel(&mut self) -> Result<(), T::Error> {
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG5_XL.addr(),
-            self.accel.ctrl_reg5_xl(),
-        )?;
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG6_XL.addr(),
-            self.accel.ctrl_reg6_xl(),
-        )?;
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG7_XL.addr(),
-            self.accel.ctrl_reg7_xl(),
-        )?;
+        self.write_register(self.accel.ctrl_reg5_xl_config())?;
+        self.write_register(self.accel.ctrl_reg6_xl_config())?;
+        self.write_register(self.accel.ctrl_reg7_xl_config())?;
         Ok(())
     }
     /// Initializes Gyro with sensor settings.
     pub fn begin_gyro(&mut self) -> Result<(), T::Error> {
-        self.interface.write(
-            Sensor::Gyro,
-            register::AG::CTRL_REG1_G.addr(),
-            self.gyro.ctrl_reg1_g(),
-        )?;
-        self.interface.write(
-            Sensor::Gyro,
-            register::AG::CTRL_REG2_G.addr(),
-            self.gyro.ctrl_reg2_g(),
-        )?;
-        self.interface.write(
-            Sensor::Gyro,
-            register::AG::CTRL_REG3_G.addr(),
-            self.gyro.ctrl_reg3_g(),
-        )?;
-        self.interface.write(
-            Sensor::Gyro,
-            register::AG::CTRL_REG4.addr(),
-            self.gyro.ctrl_reg4(),
-        )?;
+        self.write_register(self.gyro.ctrl_reg1_g_config())?;
+        self.write_register(self.gyro.ctrl_reg2_g_config())?;
+        self.write_register(self.gyro.ctrl_reg3_g_config())?;
+        self.write_register(self.gyro.ctrl_reg4_config())?;
         Ok(())
     }
     /// Initializes Magnetometer with sensor settings.
     pub fn begin_mag(&mut self) -> Result<(), T::Error> {
-        self.interface.write(
-            Sensor::Magnetometer,
-            register::Mag::CTRL_REG1_M.addr(),
-            self.mag.ctrl_reg1_m(),
-        )?;
-        self.interface.write(
-            Sensor::Magnetometer,
-            register::Mag::CTRL_REG2_M.addr(),
-            self.mag.ctrl_reg2_m(),
-        )?;
-        self.interface.write(
-            Sensor::Magnetometer,
-            register::Mag::CTRL_REG3_M.addr(),
-            self.mag.ctrl_reg3_m(),
-        )?;
-        self.interface.write(
-            Sensor::Magnetometer,
-            register::Mag::CTRL_REG4_M.addr(),
-            self.mag.ctrl_reg4_m(),
-        )?;
-        self.interface.write(
-            Sensor::Magnetometer,
-            register::Mag::CTRL_REG5_M.addr(),
-            self.mag.ctrl_reg5_m(),
-        )?;
+        self.write_register(self.mag.ctrl_reg1_m_config())?;
+        self.write_register(self.mag.ctrl_reg2_m_config())?;
+        self.write_register(self.mag.ctrl_reg3_m_config())?;
+        self.write_register(self.mag.ctrl_reg4_m_config())?;
+        self.write_register(self.mag.ctrl_reg5_m_config())?;
         Ok(())
     }
 
@@ -171,9 +144,7 @@ where
             Accelerometer | Gyro | Temperature => register::AG::STATUS_REG_1.addr(),
             Magnetometer => register::Mag::STATUS_REG_M.addr(),
         };
-        let mut bytes = [0u8; 1];
-        self.interface.read(sensor, register, &mut bytes)?;
-        Ok(bytes[0])
+        self.read_register(sensor, register)
     }
     /// Sees if new Accelerometer data is available
     pub fn accel_data_available(&mut self) -> Result<bool, T::Error> {
@@ -269,22 +240,16 @@ where
     /// Enable and configure FIFO
     pub fn configure_fifo(&mut self, config: FIFOConfig) -> Result<(), T::Error> {
         // write values to the FIFO_CTRL register
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::FIFO_CTRL.addr(),
-            config.f_fifo_ctrl(),
-        )?;
+        self.write_register(config.f_fifo_ctrl_config())?;
 
-        // write values to specific bits of the CTRL_REG9 register
         let ctrl_reg9: u8 =
             self.read_register(Sensor::Accelerometer, register::AG::CTRL_REG9.addr())?;
-        let payload = ctrl_reg9 & !FIFOBitmasks::CTRL_REG9_FIFO | config.f_ctrl_reg9();
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG9.addr(),
-            payload,
-        )?;
-        Ok(())
+        // write values to specific bits of the CTRL_REG9 register
+        self.modify_register(
+            config.f_ctrl_reg9_config(),
+            ctrl_reg9,
+            !FIFOBitmasks::CTRL_REG9_FIFO,
+        )
     }
 
     /// Get flags and FIFO level from the FIFO_STATUS register
@@ -299,41 +264,28 @@ where
     pub fn set_decimation(&mut self, decimation: Decimate) -> Result<(), T::Error> {
         let ctrl_reg5 =
             self.read_register(Sensor::Accelerometer, register::AG::CTRL_REG5_XL.addr())?;
-        let payload = ctrl_reg5 & !FIFOBitmasks::DEC | decimation.value();
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG5_XL.addr(),
-            payload,
-        )?;
-        Ok(())
+        self.modify_register(decimation, ctrl_reg5, !FIFOBitmasks::DEC)
     }
 
     /// Enable interrupts for accelerometer/gyroscope and configure the INT1_A/G interrupt pin
     pub fn configure_interrupts_ag1(&mut self, config: IntConfigAG1) -> Result<(), T::Error> {
-        self.interface.write(
-            Sensor::Accelerometer,
-            register::AG::INT1_CTRL.addr(),
-            config.int1_ctrl(),
-        )?;
-        Ok(())
+        self.write_register(config)
     }
 
     /// Enable interrupts for accelerometer/gyroscope and configure the INT2_A/G interrupt pin
     pub fn configure_interrupts_ag2(&mut self, config: IntConfigAG2) -> Result<(), T::Error> {
-        let reg_data = self.read_register(Sensor::Accelerometer, register::AG::INT2_CTRL.addr())?;
-        let data: u8 = reg_data & 0b0011_1111 | config.int2_ctrl();
-        self.interface
-            .write(Sensor::Accelerometer, register::AG::INT2_CTRL.addr(), data)?;
-        Ok(())
+        self.write_register(config)
     }
 
     /// Interrupt pins electrical configuration
     pub fn configure_interrupts_pins(&mut self, config: PinConfig) -> Result<(), T::Error> {
-        let reg_data = self.read_register(Sensor::Accelerometer, register::AG::CTRL_REG8.addr())?;
-        let data: u8 = reg_data & 0b1100_1111 | config.ctrl_reg8();
-        self.interface
-            .write(Sensor::Accelerometer, register::AG::CTRL_REG8.addr(), data)?;
-        Ok(())
+        let ctrl_reg8 =
+            self.read_register(Sensor::Accelerometer, register::AG::CTRL_REG8.addr())?;
+        self.modify_register(
+            config,
+            ctrl_reg8,
+            !(PinConfigBitmask::ACTIVE_LEVEL | PinConfigBitmask::PIN_MODE),
+        )
     }
 
     /// Get the current A/G1 pin configuration
@@ -358,6 +310,45 @@ where
             Sensor::Accelerometer,
             register::AG::CTRL_REG8.addr(),
         )?))
+    }
+
+    /// Get the current Accelerometer interrupt configuration
+    pub fn get_accel_int_config(&mut self) -> Result<IntConfigAccel, T::Error> {
+        Ok(IntConfigAccel::from(self.read_register(
+            Sensor::Accelerometer,
+            register::AG::INT_GEN_CFG_XL.addr(),
+        )?))
+    }
+
+    /// Get the current Gyro interrupt configuration
+    pub fn get_gyro_int_config(&mut self) -> Result<IntConfigGyro, T::Error> {
+        Ok(IntConfigGyro::from(self.read_register(
+            Sensor::Gyro,
+            register::AG::INT_GEN_CFG_G.addr(),
+        )?))
+    }
+
+    /// Get the current Magnetometer interrupt configuration
+    pub fn get_mag_int_config(&mut self) -> Result<IntConfigMag, T::Error> {
+        Ok(IntConfigMag::from(self.read_register(
+            Sensor::Magnetometer,
+            register::Mag::INT_CFG_M.addr(),
+        )?))
+    }
+
+    /// Configure Accelerometer interrupt
+    pub fn configure_interrupts_accel(&mut self, config: IntConfigAccel) -> Result<(), T::Error> {
+        self.write_register(config)
+    }
+
+    /// Configure Gyro interrupt
+    pub fn configure_interrupts_gyro(&mut self, config: IntConfigGyro) -> Result<(), T::Error> {
+        self.write_register(config)
+    }
+
+    /// Configure Magnetometer interrupt
+    pub fn configure_interrupts_mag(&mut self, config: IntConfigMag) -> Result<(), T::Error> {
+        self.write_register(config)
     }
 
     /// Read a byte from the given register.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,10 +254,9 @@ where
 
     /// Get flags and FIFO level from the FIFO_STATUS register
     pub fn get_fifo_status(&mut self) -> Result<FIFOStatus, T::Error> {
-        Ok(FIFOStatus::from(self.read_register(
-            Sensor::Accelerometer,
-            register::AG::FIFO_SRC.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Accelerometer, register::AG::FIFO_SRC.addr())?
+            .into())
     }
 
     /// Sets decimation of acceleration data on OUT REG and FIFO
@@ -290,50 +289,44 @@ where
 
     /// Get the current A/G1 pin configuration
     pub fn get_ag1_config(&mut self) -> Result<IntConfigAG1, T::Error> {
-        Ok(IntConfigAG1::from(self.read_register(
-            Sensor::Accelerometer,
-            register::AG::INT1_CTRL.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Accelerometer, register::AG::INT1_CTRL.addr())?
+            .into())
     }
 
     /// Get the current A/G2 pin configuration
     pub fn get_ag2_config(&mut self) -> Result<IntConfigAG2, T::Error> {
-        Ok(IntConfigAG2::from(self.read_register(
-            Sensor::Accelerometer,
-            register::AG::INT2_CTRL.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Accelerometer, register::AG::INT2_CTRL.addr())?
+            .into())
     }
 
     /// Get the current common pins configuration
     pub fn get_pins_config(&mut self) -> Result<PinConfig, T::Error> {
-        Ok(PinConfig::from(self.read_register(
-            Sensor::Accelerometer,
-            register::AG::CTRL_REG8.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Accelerometer, register::AG::CTRL_REG8.addr())?
+            .into())
     }
 
     /// Get the current Accelerometer interrupt configuration
     pub fn get_accel_int_config(&mut self) -> Result<IntConfigAccel, T::Error> {
-        Ok(IntConfigAccel::from(self.read_register(
-            Sensor::Accelerometer,
-            register::AG::INT_GEN_CFG_XL.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Accelerometer, register::AG::INT_GEN_CFG_XL.addr())?
+            .into())
     }
 
     /// Get the current Gyro interrupt configuration
     pub fn get_gyro_int_config(&mut self) -> Result<IntConfigGyro, T::Error> {
-        Ok(IntConfigGyro::from(self.read_register(
-            Sensor::Gyro,
-            register::AG::INT_GEN_CFG_G.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Gyro, register::AG::INT_GEN_CFG_G.addr())?
+            .into())
     }
 
     /// Get the current Magnetometer interrupt configuration
     pub fn get_mag_int_config(&mut self) -> Result<IntConfigMag, T::Error> {
-        Ok(IntConfigMag::from(self.read_register(
-            Sensor::Magnetometer,
-            register::Mag::INT_CFG_M.addr(),
-        )?))
+        Ok(self
+            .read_register(Sensor::Magnetometer, register::Mag::INT_CFG_M.addr())?
+            .into())
     }
 
     /// Configure Accelerometer interrupt


### PR DESCRIPTION
This PR adds interrupt functionalities. 

Use `IntConfigXXX` structs to configure interrupt settings.

And write registers by passing `ConfigToWrite` to write methods.

```rust
pub trait ConfigToWrite {
    fn byte(&self) -> u8;
    fn sensor(&self) -> Sensor;
    fn addr(&self) -> u8;
}

fn write_register<C: ConfigToWrite>(&mut self, config: C) -> Result<(), T::Error> {
    self.interface
        .write(config.sensor(), config.addr(), config.byte())?;
    Ok(())
}
```

All the config structs are `ConfigToWrite`. 

```rust
impl ConfigToWrite for IntConfigAccel {
    fn byte(&self) -> u8 {
        self.int_gen_cfg_xl()
    }
    fn sensor(&self) -> Sensor {
        Sensor::Accelerometer
    }
    fn addr(&self) -> u8 {
        register::AG::INT_GEN_CFG_XL.addr()
    }
}

impl ConfigToWrite for IntConfigGyro {
    fn byte(&self) -> u8 {
        self.int_gen_cfg_g()
    }
    fn addr(&self) -> u8 {
        register::AG::INT_GEN_CFG_G.addr()
    }
    fn sensor(&self) -> Sensor {
        Sensor::Gyro
    }
}

impl ConfigToWrite for IntConfigMag {
    fn byte(&self) -> u8 {
        self.int_cfg_m()
    }
    fn addr(&self) -> u8 {
        register::Mag::INT_CFG_M.addr()
    }
    fn sensor(&self) -> Sensor {
        Sensor::Magnetometer
    }
}
```

So, we can do this:

```rust
/// Configure Accelerometer interrupt
pub fn configure_interrupts_accel(&mut self, config: IntConfigAccel) -> Result<(), T::Error> {
    self.write_register(config)
}

/// Configure Gyro interrupt
pub fn configure_interrupts_gyro(&mut self, config: IntConfigGyro) -> Result<(), T::Error> {
    self.write_register(config)
}

/// Configure Magnetometer interrupt
pub fn configure_interrupts_mag(&mut self, config: IntConfigMag) -> Result<(), T::Error> {
    self.write_register(config)
}
```

'AccelSettings', 'GyroSettings' and 'MagSettings' also return `Configuration` which conforms to `ConfigToWrite`.

```rust
impl AccelSettings {
    /// Returns `Configuration` to write to CTRL_REG5_XL (0x1F)
    pub fn ctrl_reg5_xl_config(&self) -> Configuration {
        Configuration {
            value: self.ctrl_reg5_xl(),
            sensor: Sensor::Accelerometer,
            register: register::AG::CTRL_REG5_XL.addr(),
        }
    }

    /// Returns `Configuration` to write to CTRL_REG6_XL (0x20)
    pub fn ctrl_reg6_xl_config(&self) -> Configuration {
        Configuration {
            value: self.ctrl_reg6_xl(),
            sensor: Sensor::Accelerometer,
            register: register::AG::CTRL_REG6_XL.addr(),
        }
    }

    /// Returns `Configuration` to write to CTRL_REG7_XL (0x21)
    pub fn ctrl_reg7_xl_config(&self) -> Configuration {
        Configuration {
            value: self.ctrl_reg7_xl(),
            sensor: Sensor::Accelerometer,
            register: register::AG::CTRL_REG7_XL.addr(),
        }
    }
}

// usage in lib.rs
pub fn begin_accel(&mut self) -> Result<(), T::Error> {
    self.write_register(self.accel.ctrl_reg5_xl_config())?;
    self.write_register(self.accel.ctrl_reg6_xl_config())?;
    self.write_register(self.accel.ctrl_reg7_xl_config())?;
    Ok(())
}
```

