### PR TITLE
threshold now clamped to correct values, improved FIFO defaults

### DIFF
--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -26,7 +26,7 @@ pub struct FIFOConfig {
     /// Enable threshold level use
     pub fifo_use_threshold: bool,
     /// Set the threshold level
-    pub fifo_threshold: u8, // default 32
+    pub fifo_threshold: u8, 
     /// Store temperature data in FIFO
     pub fifo_temperature_enable: bool,
 }
@@ -34,11 +34,11 @@ pub struct FIFOConfig {
 impl Default for FIFOConfig {
     fn default() -> Self {
         FIFOConfig {
-            fifo_mode: FIFOMode::Bypass,    // Bypass mode
-            fifo_threshold: 32u8,           // set the threshold level
-            fifo_enable: false,             // disabled
+            fifo_mode: FIFOMode::FIFO,      // FIFO mode
+            fifo_threshold: 32u8,           // set the default threshold level
+            fifo_enable: true,              // FIFO enabled
             fifo_temperature_enable: false, // temperature data not stored in FIFO
-            fifo_use_threshold: false,      // FIFO depth not limited
+            fifo_use_threshold: true,       // FIFO depth limited to set threshold
         }
     }
 }
@@ -47,10 +47,21 @@ impl FIFOConfig {
     /// Returns `u8` to be written to FIFO_CTRL.  
     pub(crate) fn f_fifo_ctrl(&self) -> u8 {
         let mut data = 0u8;
+
+        // clamp the inserted threshold values as the maximum is 32
+        // threshold value must be set as t-1, i.e. to set it to 32,
+        // value 0b11111 must be written to the register
+        let threshold_data = match self.fifo_threshold {
+            0 => 0, // setting to 0 will actually set it to 1 FIFO level
+            1..=32 => self.fifo_threshold - 1,  
+            _ => 31, // every value above 32 will be set to 32 levels of FIFO
+        };
+
         data |= self.fifo_mode.value();
-        data |= self.fifo_threshold;
+        data |= threshold_data;
         data
     }
+
     /// Returns `u8` to be written to CTRL_REG9.
     pub(crate) fn f_ctrl_reg9(&self) -> u8 {
         let mut data = 0u8;


### PR DESCRIPTION
This is supposed to fix the FIFO threshold setting, by limiting the possible values to 32 and actually mapping them to [0..31] range. The datasheet says:

_"The FIFO buffer memorizes 32 levels of data but the depth of the FIFO can be resized by setting the STOP_ON_FTH bit in CTRL_REG9 (23h). If the STOP_ON_FTH bit is set to '1', FIFO depth is limited to FIFO_CTRL (2Eh)(FTH [4:0]) + 1 data."_ - so I understand it as "if we write 0, it will mean 1 FIFO level, if we write 31, it means 32 FIFO levels".

I also changed the default settings for the FIFO config, I think they make more sense now:

- FIFO is enabled
- FIFOMode is FIFO
- threshold is set to 32 and threshold is being used
- temperature is not stored in the FIFO
